### PR TITLE
Correct makefile - shared library link *.o files

### DIFF
--- a/makefile
+++ b/makefile
@@ -94,7 +94,7 @@ DSRC  = src/
 ifeq "$(SHARED)" "yes"
   DEXE    = ./shared/
   MAIN    = $(DEXE)libvtkfortran.so
-  MAKELIB = $(FC) $(OPTSL) $(DOBJ)vtkfortran.o -o $(MAIN)
+  MAKELIB = $(FC) $(OPTSL) $(DOBJ)*.o -o $(MAIN)
 endif
 ifeq "$(STATIC)" "yes"
   DEXE    = ./static/


### PR DESCRIPTION
Thank you for this great library. Upon compiling a shared library, an error was encountered. The proposed correction in the linking script (makefile) resolved it.