### PR TITLE
Add fpm support

### DIFF
--- a/.github/workflows/fpm.yml
+++ b/.github/workflows/fpm.yml
@@ -1,0 +1,53 @@
+name: fpm
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        gcc_v: [10] # Version of GFortran we want to use.
+        include:
+        - os: ubuntu-latest
+          os-arch: linux-x86_64
+
+        - os: macos-latest
+          os-arch: macos-x86_64
+
+        - os: windows-latest
+          os-arch: windows-x86_64
+            # Windows GFortran Version: 11.2
+
+    env:
+      FC: gfortran
+      GCC_V: ${{ matrix.gcc_v }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+
+    - name: Install GFortran macOS
+      if: contains(matrix.os, 'macos')
+      run: |
+        ln -s /usr/local/bin/gfortran-${GCC_V} /usr/local/bin/gfortran
+        which gfortran-${GCC_V}
+        which gfortran
+    - name: Install GFortran Linux
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
+        --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V}
+    
+    - name: Install fpm
+      uses: fortran-lang/setup-fpm@v3
+      with:
+        fpm-version: 'v0.6.0'
+
+    - name: Build StringiFor
+      run: |
+        gfortran --version
+        fpm build

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,0 +1,31 @@
+name = "VTKFortran"
+version = "2.0.3"
+author = "Stefano Zaghi"
+copyright = "Copyright © 2022, Stefano Zaghi"
+license = "Multiple licenses"
+description = "pure Fortran VTK (XML) API"
+maintainer = "Stefano Zaghi"
+homepage = "https://github.com/szaghi/VTKFortran"
+
+[library]
+source-dir = "src/lib"
+
+[install]
+library = true
+
+[dependencies]
+[dependencies.FoXy]
+git = "https://github.com/Fortran-FOSS-Programmers/FoXy"
+rev = "06f8ff513c6ff86898f825981d166f406397e958"
+
+[dependencies.PENF]
+git = "https://github.com/szaghi/PENF"
+rev = "65061235982495b158412b70c05b228af4320d94"
+
+[dependencies.BeFoR64]
+git = "https://github.com/szaghi/BeFoR64"
+rev = "09b95c08a2ee8995d19cf8551c22b783193f6246"
+
+[dependencies.StringiFor]
+git = "https://github.com/szaghi/StringiFor"
+rev = "25570c36964ef49942537af942603962c3f26b68"


### PR DESCRIPTION
- [x] Add fpm support;
- [x] Add fpm CI.

My original intention was to make `VTKFortran` buildable with `fpm`, and currently all `VTKFortran` dependencies (`FoXy`, `PENF`, `BeFoR64`, `StringiFor`) support `fpm`, that goal is about to happen. 🎉

Thanks in advance for your review, @szaghi . 💕