### PR TITLE
Update fpm.toml to fix fpm support

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -16,16 +16,16 @@ library = true
 [dependencies]
 [dependencies.FoXy]
 git = "https://github.com/Fortran-FOSS-Programmers/FoXy"
-rev = "06f8ff513c6ff86898f825981d166f406397e958"
+branch = "master"
 
 [dependencies.PENF]
 git = "https://github.com/szaghi/PENF"
-rev = "65061235982495b158412b70c05b228af4320d94"
+branch = "master"
 
 [dependencies.BeFoR64]
 git = "https://github.com/szaghi/BeFoR64"
-rev = "09b95c08a2ee8995d19cf8551c22b783193f6246"
+branch = "master"
 
 [dependencies.StringiFor]
 git = "https://github.com/szaghi/StringiFor"
-rev = "25570c36964ef49942537af942603962c3f26b68"
+branch = "master"


### PR DESCRIPTION
This is enough to solve #40, but VTKFortran’s dependencies can be updated in the same way.