### PR TITLE
Update fpm configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,17 @@ bash scripts/run_tests.sh         # run tests
 ```
 
 ### fpm
+Requires at least version v0.13.0!
 
+Building library in current directory
 ```bash
-fpm build
-fpm test
+fpm build --compiler gfortran/ifx/... --profile release
 ```
+The library may be installed to a custom location with
+```bash
+fpm install --compiler gfortran/ifx/... --profile release --prefix /target_path
+```
+Please refer to the `fpm.toml` file for further available profiles and features.
 
 ### GNU Make
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -13,6 +13,37 @@ source-dir = "src/lib"
 [install]
 library = true
 
+[features]
+#optimization
+opt.gfortran.flags = "-O3"
+opt.ifx.flags = "-O3 -ipo -inline-level=2 -heap-arrays 0"
+
+#check
+check.gfortran.flags = "-fcheck=all"
+check.ifx.flags = """-check all"""
+
+#warn
+warn.gfortran.flags = """-fmax-errors=0 -Wall -Wno-array-temporaries \
+-Warray-bounds -Wcharacter-truncation -Wline-truncation -Wconversion-extra \
+-Wimplicit-interface -Wimplicit-procedure -Wunderflow -Wextra -Wuninitialized"""
+warn.ifx.flags = "-warn all"
+
+#debug
+debug.gfortran.flags = """-fmodule-private -ffree-line-length-132 -fimplicit-none \
+-ffpe-trap=invalid,overflow -fbacktrace -fdump-core -finit-real=nan"""
+debug.ifx.flags = """-g -extend-source 132 -fpe0 -fstack-protector-all -no-ftz -traceback"""
+
+#optional openmp
+omp.gfortran.flags = "-fopenmp"
+omp.ifx.flags = "-qopenmp"
+#optional enforce 2003 standard
+std03.gfortran.flags = "-std=f2003 -fall-intrinsics"
+std03.ifx.flags = "-std03"
+
+[profiles]
+release = ["opt", "warn", "check", "debug"]
+release-omp = ["opt", "warn", "check", "debug", "omp"]
+
 [dependencies]
 [dependencies.FoXy]
 git = "https://github.com/Fortran-FOSS-Programmers/FoXy"


### PR DESCRIPTION
## Summary
This addresses issue #56  when building the library with the Fortran Package Manager. The fpm configuration file is updated to allow use of profiles and extensive features to improve build quality of library when using fpm.
Requires at least fpm in version 0.13.0!

## Motivation
The current fpm configuration file does not allow optimal compiler flags and features. This may cause issues especially when compiling with ifx. Suboptimal compiler flags caused SEGFAULT when array sizes were too big.

Closes #56 

## Changes

-added features and profiles to fpm.toml
-compiler flags transferred based on makefile
-Readme updated to reflect new fpm capability

Important note:
I could not make fpm test to work because fpm expects `tests` directory to be located in top level and I did not manage to set up custom tests. This was already not working previously.

## Checklist

- [ ] Tests added or updated
- [ ] All tests pass locally (`ctest`, `run_tests.sh`, or `fpm test`)
- [x] Docs updated if behaviour changed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format
- [x] No unrelated changes mixed in
